### PR TITLE
chore: .gitignore rules and kconfig menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,74 @@
-.pytest_cache/
-__pycache__/
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
 
-# esp-idf built binaries
+# Linux / Unix
+.directory
+*~
+*.swp
+*.swo
+*.bak
+*.tmp
+.ccache/
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Diretórios de build (Raiz e subpastas)
 build/
-build_*_*/
-sdkconfig
+**/build/
 
-# idf-ci build run output
+# Binários e arquivos gerados
+*.bin
+*.elf
+*.map
+*.o
+*.a
+*.out
+*.exe
+flasher_args.json
+
+# Configurações locais (NÃO versionar sdkconfig local)
+sdkconfig
+sdkconfig.old
+
+# Logs e relatórios de CI
+*.log
 build_summary_*.xml
 app_info_*.txt
 size_info_*.txt
-
-# pytest-embedded log folder
 pytest_embedded_log/
 
-# idf-component-manager output
+# ESP-IDF Component Manager
 dependencies.lock
+managed_components/
 
-# vscode
-.vscode/
+# Python: Bytecode e Ambientes Virtuais
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+venv/
+.venv/
+env/
+*.egg-info/
+dist/
 
-#clangd
+# clangd e Language Servers
+.clangd/
 .cache/
+.ccls-cache/
+compile_commands.json
+
+# VS Code
+.vscode/*
+!.vscode/extensions.json
+
+# Variáveis de ambiente
+.env
+.env.*
+!.env.example

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,13 +1,13 @@
 menu "Wi-Fi Configuration"
     config WIFI_SSID
         string "SSID do Wi-Fi"
-        default "MinhaRede"
+        default ""
         help
             Nome da rede Wi-Fi que o ESP32 deve conectar.
 
     config WIFI_PASSWORD
         string "Senha do Wi-Fi"
-        default "senha123"
+        default ""
         help
             Senha da rede Wi-Fi.
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,0 +1,14 @@
+menu "Wi-Fi Configuration"
+    config WIFI_SSID
+        string "SSID do Wi-Fi"
+        default "MinhaRede"
+        help
+            Nome da rede Wi-Fi que o ESP32 deve conectar.
+
+    config WIFI_PASSWORD
+        string "Senha do Wi-Fi"
+        default "senha123"
+        help
+            Senha da rede Wi-Fi.
+
+endmenu


### PR DESCRIPTION
Melhoria de configurações de ambiente e definição de parâmetros globais via Kconfig.

Alterações:

- Git: Refinamento do .gitignore para suportar artefatos do ESP-IDF, logs de build e extensões de análise (Clangd)
- Kconfig: Implementação da interface de configuração (Kconfig.projbuild) para gerenciamento de variáveis sensíveis, como credenciais Wi-Fi, MQTT e parâmetros do protocolo ESP-NOW.

Resolve #3