### PR TITLE
fix(analysis): sincroniza params.py com os tempos reais do firmware

### DIFF
--- a/analysis/params.py
+++ b/analysis/params.py
@@ -2,13 +2,13 @@
 
 LOOP_PERIOD_MS = 100            # [main/src/Application/application_controller.cpp:70]
 
-TERM_DURATION_MS = 10_000       # [main/src/Application/role_service.cpp:28]
-DISCOVERY_WINDOW_MS = 2_000     # [main/src/Application/role_service.cpp:25]
-ISOLATION_TIMEOUT_MS = 60_000   # [main/src/Application/role_service.cpp:33]
-ROTATE_RETRIES = 10             # [main/src/Application/role_service.cpp:37]
-ROTATE_RETRY_MS = 200           # [main/src/Application/role_service.cpp:38]
+TERM_DURATION_MS = 60_000       # [main/src/Application/role_service.cpp:31]
+DISCOVERY_WINDOW_MS = 2_000     # [main/src/Application/role_service.cpp:26]
+ISOLATION_TIMEOUT_MS = 60_000   # [main/src/Application/role_service.cpp:36]
+ROTATE_RETRIES = 10             # [main/src/Application/role_service.cpp:40]
+ROTATE_RETRY_MS = 200           # [main/src/Application/role_service.cpp:41]
 
-COOLDOWN_MS = 20_000            # [main/src/Application/leader_policy.cpp:31]
+COOLDOWN_MS = 120_000           # [main/src/Application/leader_policy.cpp:31]
 
 PEER_TTL_MS = 10_000            # [main/src/Application/energy_service.cpp:28]
 ENERGY_TICK_PERIOD_MS = 1_000   # [main/src/Application/energy_service.cpp:24]
@@ -23,7 +23,7 @@ READING_INTERVAL_MS = 2_000     # [main/src/Application/reading_service.cpp:9]
 BATTERY_CAPACITY_MAH = 1_000    # [main/Kconfig.projbuild AMMETER_BATTERY_CAPACITY_MAH]
 BATTERY_VOLTAGE_MV = 3_700      # [main/Kconfig.projbuild AMMETER_BATTERY_VOLTAGE_MV]
 
-# Transporte (sim). PING broadcast ~20% recepção [role_service.cpp:36 comment];
+# Transporte (sim). PING broadcast ~20% recepção [role_service.cpp:39 comment];
 # READING/ROTATE unicast confiável [network_service.cpp:198-203].
 PING_BROADCAST_LOSS = 0.80
 UNICAST_LOSS = 0.0

--- a/analysis/tests/test_metrics.py
+++ b/analysis/tests/test_metrics.py
@@ -1,5 +1,6 @@
 # analysis/tests/test_metrics.py
 import pandas as pd
+import pytest
 from analysis.simulator import sim
 from analysis.simulator.energy import ABSTRACT, calibrated
 from analysis import metrics
@@ -14,8 +15,18 @@ def test_fnd_by_policy_one_row_per_policy():
     assert set(out["policy"]) == {"round_robin", "energy"}
     assert (out["fnd_ms_mean"] > 0).all()
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="Com os tempos reais do firmware (TERM=60s, COOLDOWN=120s) o cluster vive "
+    "~24 mandatos ate o FND (eram ~420 com 10s/20s). No perfil abstract (nos "
+    "homogeneos) o 'energy' puro ja alterna sozinho e o ganho do cooldown no "
+    "desvio-padrao se perde no ruido — chega a inverter conforme as seeds. Tese a "
+    "revisitar num cenario heterogeneo (capacidade/corrente por no); ver follow-up "
+    "no spec 2026-06-18-sincroniza-params-firmware.")
 def test_cooldown_balances_better_than_energy():
     # Efeito que o artigo afirma: cooldown reduz o desvio-padrao da lideranca.
+    # NOTA: nao se sustenta de forma robusta no abstract com os tempos reais — ver
+    # o motivo no decorator xfail acima.
     df = pd.concat([many("energy"), many("energy_cooldown")], ignore_index=True)
     std = metrics.leadership_std(df).set_index("policy")["std"]
     assert std["energy_cooldown"] <= std["energy"]

--- a/analysis/tests/test_nodes.py
+++ b/analysis/tests/test_nodes.py
@@ -21,6 +21,14 @@ def run(nodes, steps):
         for n in nodes:
             n.step(now_ms=k * params.LOOP_PERIOD_MS)
 
+def _steps_mandato_e_rotacao():
+    """Passos (de LOOP_PERIOD_MS) cobrindo a eleição inicial + 1 mandato
+    completo + a rotação seguinte. Derivado de params para não voltar a quebrar
+    quando os tempos do firmware mudarem (ex.: TERM_DURATION_MS 10s -> 60s)."""
+    discovery = params.DISCOVERY_WINDOW_MS // params.LOOP_PERIOD_MS
+    term = params.TERM_DURATION_MS // params.LOOP_PERIOD_MS
+    return discovery + term + 100  # folga p/ ping inicial e propagação do ROTATE
+
 def test_smallest_mac_becomes_leader():
     t, nodes, events = make_pair()
     run(nodes, steps=40)  # > DISCOVERY_WINDOW + alguns pings
@@ -30,7 +38,7 @@ def test_smallest_mac_becomes_leader():
 
 def test_leader_rotates_after_term():
     t, nodes, events = make_pair()
-    run(nodes, steps=200)  # cobre > 1 mandato (10 s = 100 passos)
+    run(nodes, steps=_steps_mandato_e_rotacao())  # eleição + 1 mandato + rotação
     leaders = [mac for mac, ev, _ in events if ev == "became_leader"]
     assert A in leaders and B in leaders  # liderança rotacionou
 
@@ -42,6 +50,6 @@ def test_leader_energy_drains_faster_than_member():
 
 def test_rotation_mechanism_emits_rotate_sent_and_transfers_leadership():
     t, nodes, events = make_pair()
-    run(nodes, steps=200)  # cobre > 1 mandato
+    run(nodes, steps=_steps_mandato_e_rotacao())  # eleição + 1 mandato + rotação
     assert any(ev == "rotate_sent" for _, ev, _ in events)        # lider iniciou rotacao
     assert any(ev == "became_leader" and mac == B for mac, ev, _ in events)  # lideranca foi p/ B

--- a/analysis/tests/test_params_fidelity.py
+++ b/analysis/tests/test_params_fidelity.py
@@ -1,0 +1,101 @@
+"""Fidelidade: analysis/params.py espelha as constantes do firmware.
+
+O firmware é a fonte de verdade. Este teste extrai cada valor direto dos
+.cpp / Kconfig.projbuild e compara com o que está em params.py, travando a
+regressão de dessincronização (a conformância não pega isto: ela só exercita
+now_ms=1 s, dentro do cooldown para qualquer valor >= 1 s).
+
+Cada constante vira um caso parametrizado; arquivos ausentes pulam (skip)
+individualmente, espelhando o comportamento da conformância.
+"""
+import os
+import re
+
+import pytest
+
+from analysis import params
+
+HERE = os.path.dirname(__file__)
+ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+
+# Tipos de extração suportados.
+CONSTEXPR = "constexpr"      # static constexpr T NOME = <valor>;
+VTASK = "vtask"              # vTaskDelay(<valor> / portTICK_PERIOD_MS)
+HASELAPSED = "haselapsed"    # timer.hasElapsed(<valor>)
+KDEFAULT = "kdefault"        # config NOME ... default <valor>  (Kconfig)
+
+# (nome em params.py, tipo, caminho relativo, símbolo no firmware)
+SPECS = [
+    # role_service.cpp — constexpr nomeadas
+    ("DISCOVERY_WINDOW_MS", CONSTEXPR, "main/src/Application/role_service.cpp", "DISCOVERY_WINDOW_MS"),
+    ("TERM_DURATION_MS", CONSTEXPR, "main/src/Application/role_service.cpp", "TERM_DURATION_MS"),
+    ("ISOLATION_TIMEOUT_MS", CONSTEXPR, "main/src/Application/role_service.cpp", "ISOLATION_TIMEOUT_MS"),
+    ("ROTATE_RETRIES", CONSTEXPR, "main/src/Application/role_service.cpp", "ROTATE_RETRIES"),
+    ("ROTATE_RETRY_MS", CONSTEXPR, "main/src/Application/role_service.cpp", "ROTATE_RETRY_MS"),
+    # leader_policy.cpp
+    ("COOLDOWN_MS", CONSTEXPR, "main/src/Application/leader_policy.cpp", "COOLDOWN_MS"),
+    # energy_service.cpp (nota: ENERGY_TICK_PERIOD_MS <- TICK_PERIOD_MS no firmware)
+    ("INITIAL_BUDGET", CONSTEXPR, "main/src/Application/energy_service.cpp", "INITIAL_BUDGET"),
+    ("COST_MQTT", CONSTEXPR, "main/src/Application/energy_service.cpp", "COST_MQTT"),
+    ("COST_ESPNOW_SEND", CONSTEXPR, "main/src/Application/energy_service.cpp", "COST_ESPNOW_SEND"),
+    ("COST_TICK", CONSTEXPR, "main/src/Application/energy_service.cpp", "COST_TICK"),
+    ("ENERGY_TICK_PERIOD_MS", CONSTEXPR, "main/src/Application/energy_service.cpp", "TICK_PERIOD_MS"),
+    ("PEER_TTL_MS", CONSTEXPR, "main/src/Application/energy_service.cpp", "PEER_TTL_MS"),
+    # reading_service.cpp
+    ("READING_INTERVAL_MS", CONSTEXPR, "main/src/Application/reading_service.cpp", "READING_INTERVAL_MS"),
+    # derivadas (não são constexpr nomeadas)
+    ("LOOP_PERIOD_MS", VTASK, "main/src/Application/application_controller.cpp", None),
+    ("PING_PERIOD_MS", HASELAPSED, "main/src/Application/discover_service.cpp", None),
+    ("BATTERY_CAPACITY_MAH", KDEFAULT, "main/Kconfig.projbuild", "AMMETER_BATTERY_CAPACITY_MAH"),
+    ("BATTERY_VOLTAGE_MV", KDEFAULT, "main/Kconfig.projbuild", "AMMETER_BATTERY_VOLTAGE_MV"),
+]
+
+# Parâmetros só de simulação: sem contraparte numérica no firmware (derivam de
+# comentários qualitativos). Cobertos pelo teste de cobertura, não pela extração.
+SIM_ONLY = {"PING_BROADCAST_LOSS", "UNICAST_LOSS"}
+
+
+def _read(relpath):
+    with open(os.path.join(ROOT, *relpath.split("/")), encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+def _norm(digits):
+    """Normaliza literais inteiros C++/Python: remove separadores ' e _."""
+    return int(digits.replace("'", "").replace("_", ""))
+
+
+def _extract(kind, relpath, symbol):
+    src = _read(relpath)
+    if kind == CONSTEXPR:
+        m = re.search(r"constexpr\s+\w+\s+" + re.escape(symbol) + r"\s*=\s*([0-9][0-9_']*)", src)
+    elif kind == VTASK:
+        m = re.search(r"vTaskDelay\(\s*([0-9][0-9_']*)\s*/\s*portTICK_PERIOD_MS", src)
+    elif kind == HASELAPSED:
+        m = re.search(r"hasElapsed\(\s*([0-9][0-9_']*)\s*\)", src)
+    elif kind == KDEFAULT:
+        m = re.search(r"config\s+" + re.escape(symbol) + r"\b.*?default\s+([0-9][0-9_']*)", src, re.DOTALL)
+    else:
+        raise ValueError(f"tipo de extração desconhecido: {kind}")
+    assert m, f"não encontrei {symbol or kind} em {relpath}"
+    return _norm(m.group(1))
+
+
+@pytest.mark.parametrize("name,kind,relpath,symbol", SPECS, ids=[s[0] for s in SPECS])
+def test_param_espelha_firmware(name, kind, relpath, symbol):
+    if not os.path.exists(os.path.join(ROOT, *relpath.split("/"))):
+        pytest.skip(f"firmware ausente: {relpath}")
+    expected = _extract(kind, relpath, symbol)
+    actual = getattr(params, name)
+    assert actual == expected, (
+        f"{name}: params.py={actual} diverge do firmware={expected} ({relpath})")
+
+
+def test_cobertura_completa_de_params():
+    """Toda constante pública de params.py deve estar coberta pela extração de
+    fidelidade ou marcada explicitamente como parâmetro de simulação — assim
+    uma constante nova não escapa silenciosamente do contrato."""
+    publicas = {n for n in dir(params) if n[:1].isalpha() and n.isupper()}
+    cobertas = {name for name, *_ in SPECS} | SIM_ONLY
+    faltando = publicas - cobertas
+    assert not faltando, f"constantes de params.py sem cobertura de fidelidade: {sorted(faltando)}"

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -58,7 +58,7 @@ menu "Leader Election Policy"
             bool "Maior energia residual + cooldown"
             help
                 Pica o no com maior energia residual entre os que nao
-                foram lider nos ultimos 60s. Evita reentrancia rapida do
+                foram lider nos ultimos 120s. Evita reentrancia rapida do
                 mesmo no.
     endchoice
 endmenu


### PR DESCRIPTION
## O que e

Sincroniza `analysis/params.py` (o "contrato unico" sim <-> firmware) com os tempos reais do firmware na `develop`. Auditoria das 19 constantes: **so 2 divergiam em valor**.

| Constante | params.py (antes) | firmware | fonte |
|---|---|---|---|
| `TERM_DURATION_MS` | 10s | **60s** | `role_service.cpp:31` |
| `COOLDOWN_MS` | 20s | **120s** | `leader_policy.cpp:31` |

Tambem atualiza as referencias de linha do `role_service.cpp` (o arquivo cresceu) e o help do `Kconfig` (dizia 60s, agora 120s).

## Por que importava

`nodes.py` usa `TERM_DURATION_MS` e `policies.py` usa `COOLDOWN_MS`, entao a divergencia afetava a fidelidade das metricas B/C/D. **A conformancia nao pegava** (so exercita `now=1s`, dentro do cooldown pra qualquer valor >= 1s).

## Mudancas

- **`test_params_fidelity.py` (novo):** extrai cada constante direto do firmware (constexpr, `vTaskDelay`, `hasElapsed`, defaults do Kconfig) e compara com `params.py`. Trava a regressao de dessincronizacao (que ja aconteceu uma vez). 18 casos.
- **`params.py`:** TERM 10s->60s, COOLDOWN 20s->120s + refs de linha.
- **`test_nodes.py`:** os `steps=200` magicos (calibrados pra 10s) viraram derivados de `params` -> robustos a mudancas de tempo.
- **`Kconfig.projbuild`:** help do `ENERGY_COOLDOWN` 60s->120s.

## Achado pra revisar: tese do cooldown

Ao sincronizar, `test_cooldown_balances_better_than_energy` passou a falhar. A tese *"cooldown reduz o desvio-padrao da lideranca"* **nao se sustenta de forma robusta** com os tempos reais no perfil **abstract** (nos homogeneos): com ~24 mandatos ate o FND (eram ~420), o ganho do cooldown some no ruido e **inverte conforme as seeds** (nao e p-hacking-able: seeds 1..20 reprovam).

Decisao (combinada): **`xfail(strict=True)` documentado** + follow-up pra revisitar num **cenario heterogeneo** (capacidade/corrente por no), onde o cooldown tem proposito real.

## Verificacao

`python -m pytest analysis -q` -> **54 passed, 1 xfailed** (inclui a conformancia g++ contra o `leader_policy.cpp` real).
