### PR TITLE
feat(analysis): cenario heterogeneo + trade-off do cooldown

### DIFF
--- a/analysis/figures/__init__.py
+++ b/analysis/figures/__init__.py
@@ -1,4 +1,4 @@
 from analysis.figures.figures import (
     fig_energy_by_role, fig_fnd_by_policy, fig_leadership_balance,
-    fig_residual_at_fnd, fig_depletion_curves, generate_all,
+    fig_residual_at_fnd, fig_depletion_curves, fig_cooldown_tradeoff, generate_all,
 )

--- a/analysis/figures/figures.py
+++ b/analysis/figures/figures.py
@@ -112,6 +112,29 @@ def fig_depletion_curves(df, outdir) -> str:
     fig.suptitle("E — Curvas de depleção por nó")
     return _save(fig, outdir, "fig_E_curvas_deplecao")
 
+def fig_cooldown_tradeoff(df, outdir) -> str:
+    """F — Trade-off do cooldown sob heterogeneidade: justica (desvio-padrao da
+    lideranca, menor=melhor) vs durabilidade (FND, maior=melhor), energy vs
+    energy_cooldown. Correntes placeholder ate a calibracao real (item 2)."""
+    std = metrics.leadership_std(df).set_index("policy")
+    fnd = metrics.fnd_by_policy(df).set_index("policy")
+    pols = [p for p in ["energy", "energy_cooldown"] if p in std.index]
+    labels = [_POL_LABEL[p] for p in pols]
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 3.4))
+    ax1.bar(labels, [std.loc[p, "std"] for p in pols], color="#3b6ea5")
+    ax1.set_ylabel("Desvio-padrão da liderança (σ)")
+    ax1.set_title("Justiça (menor = melhor)")
+    ax2.bar(labels, [fnd.loc[p, "fnd_ms_mean"] / 1000.0 for p in pols],
+            yerr=[fnd.loc[p, "fnd_ms_std"] / 1000.0 for p in pols], capsize=4, color="#3b6ea5")
+    ax2.set_ylabel("FND (s)")
+    ax2.set_title("Durabilidade (maior = melhor)")
+    fig.suptitle("F — Trade-off justiça vs durabilidade (cluster heterogêneo)")
+    fig.text(0.5, 0.005,
+             "Correntes placeholder até a calibração (item 2); capacidades na razão 10:7:4.",
+             ha="center", fontsize=7, style="italic")
+    fig.tight_layout(rect=[0, 0.04, 1, 0.92])
+    return _save(fig, outdir, "fig_F_tradeoff_cooldown_heterogeneo")
+
 def generate_all(df, outdir, idle_ma=None) -> list[str]:
     paths = [
         fig_energy_by_role(df, outdir, idle_ma),

--- a/analysis/run.py
+++ b/analysis/run.py
@@ -8,6 +8,29 @@ from analysis import figures
 
 POLICIES = ("round_robin", "energy", "energy_cooldown")
 
+# Cenario heterogeneo: capacidades de bateria distintas por no (razao 10:7:4).
+# Escala em mAh escolhida p/ FND em ~dezenas de mandatos (rapido); correntes
+# placeholder ate a calibracao real (item 2). Ver spec cooldown-heterogeneo.
+HETERO_CAPACITIES = (10.0, 7.0, 4.0)
+
+def hetero_frames(seeds=(1, 2, 3, 4, 5), capacities=HETERO_CAPACITIES,
+                  leader_ma=120.0, member_ma=25.0, idle_ma=8.0):
+    """energy vs energy_cooldown num cluster HETEROGENEO (capacidades distintas
+    por no). Retorna o DataFrame no contrato unico (sim). E onde a vantagem de
+    balanceamento do cooldown se manifesta: o energy puro favorece o no de maior
+    capacidade (mais residual), o cooldown forca a vez aos demais."""
+    profiles = [calibrated(leader_ma, member_ma, idle_ma, capacity_mah=c) for c in capacities]
+    frames = []
+    for pol in ("energy", "energy_cooldown"):
+        for s in seeds:
+            frames.append(sim.run_frame(len(capacities), pol, profiles[0], s, profiles=profiles))
+    return pd.concat(frames, ignore_index=True)
+
+def generate_hetero(outdir, seeds=(1, 2, 3, 4, 5)):
+    """Gera a figura F (trade-off justica vs durabilidade) no cluster heterogeneo."""
+    df = hetero_frames(seeds=seeds)
+    return [figures.fig_cooldown_tradeoff(df, outdir)]
+
 def generate(outdir, profile_name="abstract", cluster_size=3, seeds=(1,2,3,4,5),
              leader_ma=120.0, member_ma=25.0, idle_ma=8.0):
     profile = ABSTRACT if profile_name == "abstract" else calibrated(leader_ma, member_ma, idle_ma)
@@ -27,9 +50,14 @@ def main():
     ap.add_argument("--leader-ma", type=float, default=120.0)
     ap.add_argument("--member-ma", type=float, default=25.0)
     ap.add_argument("--idle-ma", type=float, default=8.0)
+    ap.add_argument("--hetero", action="store_true",
+                    help="Gera a figura F (trade-off do cooldown em cluster heterogeneo)")
     a = ap.parse_args()
-    paths = generate(a.out, a.profile, a.cluster_size, tuple(a.seeds),
-                     a.leader_ma, a.member_ma, a.idle_ma)
+    if a.hetero:
+        paths = generate_hetero(a.out, tuple(a.seeds))
+    else:
+        paths = generate(a.out, a.profile, a.cluster_size, tuple(a.seeds),
+                         a.leader_ma, a.member_ma, a.idle_ma)
     for p in paths:
         print(p)
 

--- a/analysis/simulator/sim.py
+++ b/analysis/simulator/sim.py
@@ -9,11 +9,16 @@ def make_macs(n: int) -> list[bytes]:
     return [bytes([0, 0, 0, 0, 0, i + 1]) for i in range(n)]
 
 def run(cluster_size, strategy, profile, seed, max_ms=5_000_000,
-        sample_period_ms=params.PING_PERIOD_MS, stop_at_fnd=True) -> list[dict]:
+        sample_period_ms=params.PING_PERIOD_MS, stop_at_fnd=True,
+        profiles=None) -> list[dict]:
     # max_ms é só um teto de segurança: com stop_at_fnd=True a execução para no
     # FND real (~3600 s no perfil abstract com N=3), então não roda até max_ms.
     rng = random.Random(seed)
     macs = make_macs(cluster_size)
+    if profiles is None:
+        profiles = [profile] * cluster_size
+    elif len(profiles) != cluster_size:
+        raise ValueError(f"profiles ({len(profiles)}) != cluster_size ({cluster_size})")
     transport = Transport(rng, macs, ping_loss=params.PING_BROADCAST_LOSS,
                           unicast_loss=params.UNICAST_LOSS)
     run_id = f"{strategy}-{profile.name}-N{cluster_size}-s{seed}"
@@ -24,13 +29,13 @@ def run(cluster_size, strategy, profile, seed, max_ms=5_000_000,
         return dict(run_id=run_id, source="sim", policy=strategy,
                     cluster_size=cluster_size, node_id=mac_to_id[node.mac],
                     t_ms=now_ms, event=event, role=node.role,
-                    current_ma=profile.current_for(node.role), power_mw=float("nan"),
-                    residual=node.energy.residual, residual_pct=_pct(node, profile))
+                    current_ma=node.profile.current_for(node.role), power_mw=float("nan"),
+                    residual=node.energy.residual, residual_pct=_pct(node))
 
     def emit(node, now_ms, event):
         rows.append(base_row(node, now_ms, event))
 
-    nodes = [Node(m, profile, strategy, transport, emit) for m in macs]
+    nodes = [Node(m, profiles[i], strategy, transport, emit) for i, m in enumerate(macs)]
 
     t = 0
     last_sample = -sample_period_ms
@@ -47,8 +52,8 @@ def run(cluster_size, strategy, profile, seed, max_ms=5_000_000,
         t += params.LOOP_PERIOD_MS
     return rows
 
-def _pct(node, profile) -> float:
-    return 100.0 * node.energy.residual / profile.initial
+def _pct(node) -> float:
+    return 100.0 * node.energy.residual / node.profile.initial
 
 def run_frame(*args, **kwargs):
     return contract.to_frame(run(*args, **kwargs))

--- a/analysis/tests/test_figures.py
+++ b/analysis/tests/test_figures.py
@@ -40,3 +40,9 @@ def test_generate_all_calibrated_returns_five_with_idle(tmp_path):
     assert len(paths) == 5
     for p in paths:
         assert os.path.exists(p) and os.path.getsize(p) > 0
+
+def test_fig_f_tradeoff_writes_file(tmp_path):
+    from analysis import run
+    df = run.hetero_frames(seeds=(1,))
+    path = figures.fig_cooldown_tradeoff(df, str(tmp_path))
+    assert path is not None and os.path.exists(path) and os.path.getsize(path) > 0

--- a/analysis/tests/test_metrics.py
+++ b/analysis/tests/test_metrics.py
@@ -20,9 +20,9 @@ def test_fnd_by_policy_one_row_per_policy():
     reason="Com os tempos reais do firmware (TERM=60s, COOLDOWN=120s) o cluster vive "
     "~24 mandatos ate o FND (eram ~420 com 10s/20s). No perfil abstract (nos "
     "homogeneos) o 'energy' puro ja alterna sozinho e o ganho do cooldown no "
-    "desvio-padrao se perde no ruido — chega a inverter conforme as seeds. Tese a "
-    "revisitar num cenario heterogeneo (capacidade/corrente por no); ver follow-up "
-    "no spec 2026-06-18-sincroniza-params-firmware.")
+    "desvio-padrao se perde no ruido — chega a inverter conforme as seeds. O efeito "
+    "SE confirma no cenario heterogeneo: ver test_cooldown_reduz_std_no_heterogeneo "
+    "(capacidades de bateria distintas).")
 def test_cooldown_balances_better_than_energy():
     # Efeito que o artigo afirma: cooldown reduz o desvio-padrao da lideranca.
     # NOTA: nao se sustenta de forma robusta no abstract com os tempos reais — ver
@@ -30,6 +30,17 @@ def test_cooldown_balances_better_than_energy():
     df = pd.concat([many("energy"), many("energy_cooldown")], ignore_index=True)
     std = metrics.leadership_std(df).set_index("policy")["std"]
     assert std["energy_cooldown"] <= std["energy"]
+
+
+def test_cooldown_reduz_std_no_heterogeneo():
+    # Contraponto ao xfail homogeneo acima: com capacidades de bateria distintas
+    # o energy puro favorece o no "rico" (monopoliza a lideranca) e o cooldown
+    # distribui -> desvio-padrao da lideranca menor. Efeito robusto (validado
+    # ~4.9 vs ~1.9). E onde a tese do artigo de fato se sustenta.
+    from analysis import run
+    df = run.hetero_frames(seeds=(1, 2, 3, 4, 5))
+    std = metrics.leadership_std(df).set_index("policy")["std"]
+    assert std["energy_cooldown"] < std["energy"]
 
 def test_depletion_curves_have_time_and_pct():
     df = many("round_robin", seeds=(1,))

--- a/analysis/tests/test_run.py
+++ b/analysis/tests/test_run.py
@@ -7,3 +7,8 @@ def test_generate_abstract_skips_fig_a(tmp_path):
     paths = run.generate(str(tmp_path), profile_name="abstract", seeds=(1, 2))
     assert len(paths) == 4
     assert all(os.path.exists(p) for p in paths)
+
+def test_generate_hetero_writes_tradeoff_fig(tmp_path):
+    # Cenario heterogeneo gera a figura F do trade-off do cooldown.
+    paths = run.generate_hetero(str(tmp_path), seeds=(1,))
+    assert len(paths) == 1 and all(os.path.exists(p) for p in paths)

--- a/analysis/tests/test_sim.py
+++ b/analysis/tests/test_sim.py
@@ -1,6 +1,7 @@
 # analysis/tests/test_sim.py
+import pytest
 from analysis.simulator import sim
-from analysis.simulator.energy import ABSTRACT
+from analysis.simulator.energy import ABSTRACT, calibrated
 from analysis import contract
 
 def test_run_emits_valid_contract():
@@ -20,3 +21,22 @@ def test_runs_are_deterministic_per_seed():
     a = sim.run_frame(cluster_size=3, strategy="energy", profile=ABSTRACT, seed=7, max_ms=60_000)
     b = sim.run_frame(cluster_size=3, strategy="energy", profile=ABSTRACT, seed=7, max_ms=60_000)
     assert a.equals(b)
+
+def test_run_aplica_profile_por_no():
+    # Heterogeneidade: cada no recebe seu profile. O residual_pct deve ser
+    # relativo a capacidade DO NO, nao a um profile global unico — entao dois
+    # nos com capacidades diferentes comecam ambos perto de 100% da propria.
+    grande = calibrated(120, 25, 8, capacity_mah=1.0)
+    pequeno = calibrated(120, 25, 8, capacity_mah=0.5)
+    rows = sim.run(cluster_size=2, strategy="round_robin", profile=grande,
+                   seed=1, profiles=[grande, pequeno], max_ms=300, stop_at_fnd=False)
+    df = contract.to_frame(rows)
+    primeiros = df[df["event"] == "sample"].sort_values("t_ms").groupby("node_id").head(1)
+    assert len(primeiros) == 2
+    assert (primeiros["residual_pct"] > 95).all()
+
+def test_run_rejeita_profiles_de_tamanho_errado():
+    grande = calibrated(120, 25, 8, capacity_mah=1.0)
+    with pytest.raises((ValueError, AssertionError)):
+        sim.run(cluster_size=3, strategy="round_robin", profile=grande,
+                seed=1, profiles=[grande, grande], max_ms=300)


### PR DESCRIPTION
## O que e

Follow-up do #14: a tese *"energy_cooldown reduz o desvio-padrao da lideranca"* nao se sustentava no perfil **abstract homogeneo** (ficou `xfail`). Este PR mostra **onde ela se sustenta** — num cluster **heterogeneo** (capacidades de bateria distintas) — e mede o **trade-off completo** justica x durabilidade.

## Resultado (figura F · cenario 10/7/4 mAh · N=3 · 5 seeds)

| politica | σ da lideranca (justica, menor=melhor) | FND medio (durabilidade, maior=melhor) |
|---|---|---|
| `energy` | 4.93 | ~1336 s |
| `energy_cooldown` | **1.87** (−62%) | ~1129 s (−15%) |

Sob heterogeneidade o `energy` puro favorece o no de maior carga (o fraco lidera 11x, os fortes 55/52) → lideranca concentrada. O cooldown distribui (o fraco lidera 26x) ao custo de ~15% de FND (drena o fraco mais cedo). Trade-off claro e defensavel numa banca.

## Mudancas

- **`sim.run` aceita `profiles` por no** (heterogeneidade), retrocompativel — sem `profiles` o comportamento atual e mantido (figuras A–E intactas). `base_row`/`_pct` passam a usar o profile **do no** (corrige `residual_pct` sob capacidades distintas).
- **`run.hetero_frames` + `generate_hetero` + CLI `--hetero`** para gerar o cenario/figura.
- **Figura F:** justica (σ da lideranca) x durabilidade (FND), `energy` vs `energy_cooldown`.
- **Testes:** `test_cooldown_reduz_std_no_heterogeneo` trava a tese; o `xfail` homogeneo aponta pra ela (narrativa completa); + API de profiles por no e smoke da figura.

## Ressalva

Correntes ainda **placeholder** (120/25/8 mA) ate a calibracao real (item 2); os valores absolutos de FND se refinam la, mas o **comparativo** energy x cooldown ja vale. Capacidades na razao 10:7:4 (escala p/ FND rapido).

## Verificacao

`python -m pytest analysis -q` → **59 passed, 1 xfailed** (inclui a conformancia g++). Figura F conferida visualmente.
