### PR TITLE
feat(analysis): calibracao de correntes por papel (firmware CALIB + parser + CLI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ logs/
 # Saída gerada da análise (figuras regeneráveis pela CLI)
 analysis/out/
 
+# Figuras geradas localmente em lote (regeneráveis; não versionar)
+resultados/
+
 *.db
 docs/superpowers/*
 analysis/conformance/oracle/build/

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -14,9 +14,12 @@ python -m analysis.run --out analysis/out
 ```
 
 ## Perfil calibrado (energia absoluta a partir das medições do ammeter)
+As correntes por papel vivem em `analysis/calibration.py` (fonte única) e podem
+ser sobrepostas na linha de comando:
 ```
 python -m analysis.run --profile calibrated --leader-ma 120 --member-ma 25 --idle-ma 8 --out analysis/out
 ```
+Para extrair as correntes dos logs do laboratório: `python -m analysis.calibration logs/`.
 
 ## Testes
 ```

--- a/analysis/calibration.py
+++ b/analysis/calibration.py
@@ -1,0 +1,11 @@
+"""Correntes calibradas por papel (medições do ammeter) — ponto único de verdade.
+
+Origem: PLACEHOLDER (estimativa) até a medição no laboratório da PUC. Para
+atualizar, rode `python -m analysis.calibration <dir_de_logs>` e cole os três
+valores abaixo, registrando a data e os arquivos de origem.
+"""
+
+# Correntes por papel, em mA. PLACEHOLDER até a calibração real (item 2).
+LEADER_MA = 120.0
+MEMBER_MA = 25.0
+IDLE_MA = 8.0

--- a/analysis/calibration.py
+++ b/analysis/calibration.py
@@ -34,42 +34,62 @@ def _ts(line):
     return int(m.group(1)) if m else None
 
 
-def _iter_calib(lines):
-    """Linhas CALIB: cada uma já traz o papel; nada a inferir."""
+def _settled(ts, transition_ts, settle_ms):
+    if settle_ms <= 0 or ts is None or transition_ts is None:
+        return True
+    return ts - transition_ts >= settle_ms
+
+
+def _iter_calib(lines, settle_ms=0):
+    """Linhas CALIB: cada uma traz o papel. Marca transição quando o papel muda
+    entre amostras consecutivas e descarta o transiente."""
+    role = None
+    transition_ts = None
     for line in lines:
         m = _CALIB_RE.search(line)
-        if m:
-            yield m.group(1).upper(), float(m.group(2))
+        if not m:
+            continue
+        ts = _ts(line)
+        new_role, cur = m.group(1).upper(), float(m.group(2))
+        if new_role != role:
+            role, transition_ts = new_role, ts
+        if _settled(ts, transition_ts, settle_ms):
+            yield role, cur
 
 
-def _iter_fallback(lines):
-    """Sem CALIB: papel inferido das transições ROLE_SERVICE; corrente das
-    linhas AMMETER. Antes da 1a eleição (ou após reboot) o papel é IDLE."""
+def _iter_fallback(lines, settle_ms=0):
+    """Sem CALIB: papel das transições ROLE_SERVICE; corrente das linhas AMMETER.
+    Antes da 1a eleição (ou após reboot) o papel é IDLE."""
     role = "IDLE"
+    transition_ts = None
     last_ts = None
     for line in lines:
         ts = _ts(line)
         if ts is not None and last_ts is not None and ts < last_ts:
-            role = "IDLE"  # reboot: timestamp volta a subir do zero
+            role, transition_ts = "IDLE", ts  # reboot
         if ts is not None:
             last_ts = ts
         mr = _ROLE_RE.search(line)
         if mr:
-            role = mr.group(1).upper()
+            new_role = mr.group(1).upper()
+            if new_role != role:
+                role, transition_ts = new_role, ts
             continue
         ma = _AMMETER_RE.search(line)
-        if ma:
+        if ma and _settled(ts, transition_ts, settle_ms):
             yield role, float(ma.group(1))
 
 
-def parse_logs(paths):
-    """Lê os logs e agrega a corrente por papel. Prefere as linhas CALIB; cai
-    para ROLE_SERVICE+AMMETER quando o arquivo não tem CALIB."""
+def parse_logs(paths, settle_ms=0):
+    """Lê os logs e agrega a corrente por papel. Prefere CALIB; cai para
+    ROLE_SERVICE+AMMETER sem CALIB. `settle_ms` descarta o transiente logo após
+    cada troca de papel."""
     buckets = {}
     for p in paths:
         lines = Path(p).read_text(errors="replace").splitlines()
         has_calib = any(_CALIB_RE.search(l) for l in lines)
-        it = _iter_calib(lines) if has_calib else _iter_fallback(lines)
+        it = (_iter_calib(lines, settle_ms) if has_calib
+              else _iter_fallback(lines, settle_ms))
         for role, cur in it:
             buckets.setdefault(role, []).append(cur)
     return {

--- a/analysis/calibration.py
+++ b/analysis/calibration.py
@@ -5,7 +5,9 @@ atualizar, rode `python -m analysis.calibration <dir_de_logs>` e cole os três
 valores abaixo, registrando a data e os arquivos de origem.
 """
 
+import argparse
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from statistics import mean, pstdev
@@ -96,3 +98,53 @@ def parse_logs(paths, settle_ms=0):
         r: RoleStats(r, mean(v), pstdev(v) if len(v) > 1 else 0.0, len(v))
         for r, v in sorted(buckets.items())
     }
+
+
+_ROLES = ("LEADER", "MEMBER", "IDLE")
+
+
+def _format_report(stats):
+    out = []
+    for role in _ROLES:
+        s = stats.get(role)
+        if s:
+            out.append(f"# {role:<6} n={s.count:<4} "
+                       f"media={s.mean_ma:.2f}mA  sigma={s.std_ma:.2f}mA")
+        else:
+            out.append(f"# {role:<6} (sem amostras - faltou medir este papel)")
+    out.append("")
+    out.append("# Cole em analysis/calibration.py:")
+    for role, const in (("LEADER", "LEADER_MA"), ("MEMBER", "MEMBER_MA"),
+                        ("IDLE", "IDLE_MA")):
+        s = stats.get(role)
+        val = f"{s.mean_ma:.1f}" if s else "None  # FALTOU medir"
+        out.append(f"{const} = {val}")
+    return "\n".join(out)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="python -m analysis.calibration",
+        description="Extrai as correntes por papel dos logs seriais.")
+    ap.add_argument("paths", nargs="+", help="diretorio de logs ou arquivos .log")
+    ap.add_argument("--settle-ms", type=int, default=5000,
+                    help="descarta amostras nos primeiros ms apos troca de papel")
+    a = ap.parse_args(argv)
+
+    files = []
+    for p in a.paths:
+        pp = Path(p)
+        files.extend(sorted(pp.glob("*.log")) if pp.is_dir() else [pp])
+    if not files:
+        print("Nenhum log encontrado. "
+              "Uso: python -m analysis.calibration <dir|arquivos> [--settle-ms N]")
+        return 1
+
+    stats = parse_logs(files, settle_ms=a.settle_ms)
+    print(f"# Fonte: {', '.join(str(f) for f in files)}  (settle={a.settle_ms}ms)")
+    print(_format_report(stats))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/analysis/calibration.py
+++ b/analysis/calibration.py
@@ -5,7 +5,74 @@ atualizar, rode `python -m analysis.calibration <dir_de_logs>` e cole os três
 valores abaixo, registrando a data e os arquivos de origem.
 """
 
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean, pstdev
+
 # Correntes por papel, em mA. PLACEHOLDER até a calibração real (item 2).
 LEADER_MA = 120.0
 MEMBER_MA = 25.0
 IDLE_MA = 8.0
+
+_CALIB_RE = re.compile(r"CALIB:\s*role=(\w+)\s+I=(-?\d+(?:\.\d+)?)mA")
+_ROLE_RE = re.compile(r"ROLE_SERVICE:\s*Role:\s*(LEADER|MEMBER)")
+_AMMETER_RE = re.compile(r"AMMETER\w*:\s*I=(-?\d+(?:\.\d+)?)mA")
+_TS_RE = re.compile(r"^\s*[IWED]\s*\((\d+)\)")
+
+
+@dataclass(frozen=True)
+class RoleStats:
+    role: str
+    mean_ma: float
+    std_ma: float
+    count: int
+
+
+def _ts(line):
+    m = _TS_RE.search(line)
+    return int(m.group(1)) if m else None
+
+
+def _iter_calib(lines):
+    """Linhas CALIB: cada uma já traz o papel; nada a inferir."""
+    for line in lines:
+        m = _CALIB_RE.search(line)
+        if m:
+            yield m.group(1).upper(), float(m.group(2))
+
+
+def _iter_fallback(lines):
+    """Sem CALIB: papel inferido das transições ROLE_SERVICE; corrente das
+    linhas AMMETER. Antes da 1a eleição (ou após reboot) o papel é IDLE."""
+    role = "IDLE"
+    last_ts = None
+    for line in lines:
+        ts = _ts(line)
+        if ts is not None and last_ts is not None and ts < last_ts:
+            role = "IDLE"  # reboot: timestamp volta a subir do zero
+        if ts is not None:
+            last_ts = ts
+        mr = _ROLE_RE.search(line)
+        if mr:
+            role = mr.group(1).upper()
+            continue
+        ma = _AMMETER_RE.search(line)
+        if ma:
+            yield role, float(ma.group(1))
+
+
+def parse_logs(paths):
+    """Lê os logs e agrega a corrente por papel. Prefere as linhas CALIB; cai
+    para ROLE_SERVICE+AMMETER quando o arquivo não tem CALIB."""
+    buckets = {}
+    for p in paths:
+        lines = Path(p).read_text(errors="replace").splitlines()
+        has_calib = any(_CALIB_RE.search(l) for l in lines)
+        it = _iter_calib(lines) if has_calib else _iter_fallback(lines)
+        for role, cur in it:
+            buckets.setdefault(role, []).append(cur)
+    return {
+        r: RoleStats(r, mean(v), pstdev(v) if len(v) > 1 else 0.0, len(v))
+        for r, v in sorted(buckets.items())
+    }

--- a/analysis/calibration.py
+++ b/analysis/calibration.py
@@ -7,6 +7,7 @@ valores abaixo, registrando a data e os arquivos de origem.
 
 import argparse
 import re
+import sqlite3
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -100,6 +101,38 @@ def parse_logs(paths, settle_ms=0):
     }
 
 
+def parse_db(db_path, settle_samples=5, min_ma=0.5):
+    """Le as leituras gravadas pelo server_mqtt.py (SQLite) e agrega a corrente
+    por papel. Cada no publica seu papel (LEADER/MEMBER) no payload MQTT; o
+    IDLE nao chega por MQTT (Wi-Fi desligado quando isolado). Por no, descarta
+    as primeiras `settle_samples` amostras apos cada troca de papel (transiente
+    de Wi-Fi) e ignora leituras <= `min_ma` (INA219 falho publica 0.0)."""
+    con = sqlite3.connect(db_path)
+    try:
+        rows = con.execute(
+            "SELECT topico, papel, corrente_ma FROM leituras "
+            "WHERE papel IS NOT NULL AND corrente_ma IS NOT NULL ORDER BY id"
+        ).fetchall()
+    finally:
+        con.close()
+    buckets = {}
+    state = {}  # topico -> (papel_atual, n_amostras_no_papel)
+    for topico, papel, cur in rows:
+        papel = papel.upper()
+        role, since = state.get(topico, (None, 0))
+        since = 0 if papel != role else since + 1
+        state[topico] = (papel, since)
+        if cur <= min_ma:  # INA219 falho / sem medicao
+            continue
+        if since < settle_samples:  # transiente apos troca de papel
+            continue
+        buckets.setdefault(papel, []).append(cur)
+    return {
+        r: RoleStats(r, mean(v), pstdev(v) if len(v) > 1 else 0.0, len(v))
+        for r, v in sorted(buckets.items())
+    }
+
+
 _ROLES = ("LEADER", "MEMBER", "IDLE")
 
 
@@ -126,18 +159,33 @@ def main(argv=None):
     ap = argparse.ArgumentParser(
         prog="python -m analysis.calibration",
         description="Extrai as correntes por papel dos logs seriais.")
-    ap.add_argument("paths", nargs="+", help="diretorio de logs ou arquivos .log")
+    ap.add_argument("paths", nargs="+",
+                    help="diretorio/arquivos .log, ou o .db do server_mqtt.py")
     ap.add_argument("--settle-ms", type=int, default=5000,
-                    help="descarta amostras nos primeiros ms apos troca de papel")
+                    help="logs: descarta amostras nos primeiros ms apos troca de papel")
+    ap.add_argument("--settle-samples", type=int, default=5,
+                    help="db: descarta as N primeiras amostras por no apos troca de papel")
     a = ap.parse_args(argv)
+
+    # Fonte SQLite (server_mqtt.py): traz LEADER e MEMBER; IDLE nao chega por MQTT.
+    db_paths = [p for p in a.paths if str(p).endswith(".db")]
+    if db_paths:
+        if len(a.paths) > 1:
+            print("Passe um unico .db (ou apenas arquivos de log, nao misture).")
+            return 1
+        db = db_paths[0]
+        stats = parse_db(db, settle_samples=a.settle_samples)
+        print(f"# Fonte: {db}  (DB MQTT, settle={a.settle_samples} amostras/no)")
+        print(_format_report(stats))
+        return 0
 
     files = []
     for p in a.paths:
         pp = Path(p)
         files.extend(sorted(pp.glob("*.log")) if pp.is_dir() else [pp])
     if not files:
-        print("Nenhum log encontrado. "
-              "Uso: python -m analysis.calibration <dir|arquivos> [--settle-ms N]")
+        print("Nenhum log encontrado. Uso: python -m analysis.calibration "
+              "<dir|arquivos.log|arquivo.db> [--settle-ms N | --settle-samples N]")
         return 1
 
     stats = parse_logs(files, settle_ms=a.settle_ms)

--- a/analysis/figures/figures.py
+++ b/analysis/figures/figures.py
@@ -52,8 +52,11 @@ def fig_energy_by_role(df, outdir, idle_ma=None) -> str | None:
     ax.set_title("A — Consumo por papel")
     return _save(fig, outdir, "fig_A_energia_por_papel")
 
-def fig_fnd_by_policy(df, outdir) -> str:
+def fig_fnd_by_policy(df, outdir) -> str | None:
     d = metrics.fnd_by_policy(df).set_index("policy").reindex(_POL_ORDER).dropna().reset_index()
+    if d.empty:
+        log.warning("Figura B requer FND (nenhum no morreu no horizonte); pulada.")
+        return None
     fig, ax = plt.subplots(figsize=(5, 3.2))
     ax.bar([_POL_LABEL[p] for p in d["policy"]], d["fnd_ms_mean"] / 1000.0,
            yerr=d["fnd_ms_std"] / 1000.0, capsize=4, color="#3b6ea5")
@@ -77,8 +80,11 @@ def fig_leadership_balance(df, outdir) -> str:
     ax.legend(title="Nó", fontsize=8)
     return _save(fig, outdir, "fig_C_balanceamento_lideranca")
 
-def fig_residual_at_fnd(df, outdir) -> str:
+def fig_residual_at_fnd(df, outdir) -> str | None:
     d = metrics.residual_at_fnd(df)
+    if d.empty:
+        log.warning("Figura D requer FND (nenhum no morreu no horizonte); pulada.")
+        return None
     spread = metrics.residual_spread(df).set_index("policy")
     fig, ax = plt.subplots(figsize=(6, 3.2))
     pols = [p for p in _POL_ORDER if p in set(d["policy"])]

--- a/analysis/metrics/metrics.py
+++ b/analysis/metrics/metrics.py
@@ -58,6 +58,8 @@ def residual_at_fnd(df: pd.DataFrame) -> pd.DataFrame:
         for _, r in last.iterrows():
             out.append(dict(policy=policy, run_id=run_id,
                             node_id=r["node_id"], residual=r["residual"]))
+    if not out:  # nenhum FND alcancado (ex.: calibrado c/ capacidade real) -> vazio-valido
+        return pd.DataFrame(columns=["policy", "node_id", "residual"])
     res = pd.DataFrame(out)
     return res.groupby(["policy", "node_id"])["residual"].mean().reset_index()
 
@@ -75,6 +77,8 @@ def residual_spread(df: pd.DataFrame) -> pd.DataFrame:
         spread = survivors.std()
         rows.append(dict(policy=policy, run_id=run_id,
                          spread=0.0 if pd.isna(spread) else spread))
+    if not rows:  # nenhum FND alcancado -> vazio-valido (nao quebra no groupby)
+        return pd.DataFrame(columns=["policy", "spread"])
     res = pd.DataFrame(rows)
     return res.groupby("policy")["spread"].mean().reset_index().fillna(0.0)
 

--- a/analysis/run.py
+++ b/analysis/run.py
@@ -5,6 +5,7 @@ import pandas as pd
 from analysis.simulator import sim
 from analysis.simulator.energy import ABSTRACT, calibrated
 from analysis import figures
+from analysis import calibration
 
 POLICIES = ("round_robin", "energy", "energy_cooldown")
 
@@ -14,7 +15,8 @@ POLICIES = ("round_robin", "energy", "energy_cooldown")
 HETERO_CAPACITIES = (10.0, 7.0, 4.0)
 
 def hetero_frames(seeds=(1, 2, 3, 4, 5), capacities=HETERO_CAPACITIES,
-                  leader_ma=120.0, member_ma=25.0, idle_ma=8.0):
+                  leader_ma=calibration.LEADER_MA, member_ma=calibration.MEMBER_MA,
+                  idle_ma=calibration.IDLE_MA):
     """energy vs energy_cooldown num cluster HETEROGENEO (capacidades distintas
     por no). Retorna o DataFrame no contrato unico (sim). E onde a vantagem de
     balanceamento do cooldown se manifesta: o energy puro favorece o no de maior
@@ -32,7 +34,8 @@ def generate_hetero(outdir, seeds=(1, 2, 3, 4, 5)):
     return [figures.fig_cooldown_tradeoff(df, outdir)]
 
 def generate(outdir, profile_name="abstract", cluster_size=3, seeds=(1,2,3,4,5),
-             leader_ma=120.0, member_ma=25.0, idle_ma=8.0):
+             leader_ma=calibration.LEADER_MA, member_ma=calibration.MEMBER_MA,
+             idle_ma=calibration.IDLE_MA):
     profile = ABSTRACT if profile_name == "abstract" else calibrated(leader_ma, member_ma, idle_ma)
     frames = []
     for pol in POLICIES:
@@ -47,9 +50,9 @@ def main():
     ap.add_argument("--profile", choices=["abstract", "calibrated"], default="abstract")
     ap.add_argument("--cluster-size", type=int, default=3)
     ap.add_argument("--seeds", type=int, nargs="+", default=[1,2,3,4,5])
-    ap.add_argument("--leader-ma", type=float, default=120.0)
-    ap.add_argument("--member-ma", type=float, default=25.0)
-    ap.add_argument("--idle-ma", type=float, default=8.0)
+    ap.add_argument("--leader-ma", type=float, default=calibration.LEADER_MA)
+    ap.add_argument("--member-ma", type=float, default=calibration.MEMBER_MA)
+    ap.add_argument("--idle-ma", type=float, default=calibration.IDLE_MA)
     ap.add_argument("--hetero", action="store_true",
                     help="Gera a figura F (trade-off do cooldown em cluster heterogeneo)")
     a = ap.parse_args()

--- a/analysis/tests/test_calibration.py
+++ b/analysis/tests/test_calibration.py
@@ -1,5 +1,6 @@
 import inspect
 from analysis import calibration, run
+from analysis.calibration import parse_logs, RoleStats
 
 
 def test_constantes_sao_floats():
@@ -14,3 +15,45 @@ def test_run_usa_as_constantes_centrais():
         assert sig.parameters["leader_ma"].default == calibration.LEADER_MA
         assert sig.parameters["member_ma"].default == calibration.MEMBER_MA
         assert sig.parameters["idle_ma"].default == calibration.IDLE_MA
+
+
+def test_parse_logs_calib_agrupa_por_papel(tmp_path):
+    log = tmp_path / "ttyUSB0.log"
+    log.write_text(
+        "I (3050) CALIB: role=IDLE I=8.0mA bat=100.0%\n"
+        "I (4050) CALIB: role=LEADER I=120.0mA bat=99.9%\n"
+        "I (5050) CALIB: role=LEADER I=122.0mA bat=99.8%\n"
+        "I (6050) CALIB: role=MEMBER I=24.0mA bat=99.7%\n"
+    )
+    stats = parse_logs([log])
+    assert isinstance(stats["LEADER"], RoleStats)
+    assert stats["LEADER"].count == 2
+    assert stats["LEADER"].mean_ma == 121.0
+    assert stats["MEMBER"].mean_ma == 24.0
+    assert stats["IDLE"].mean_ma == 8.0
+
+
+def test_parse_logs_fallback_sem_calib(tmp_path):
+    log = tmp_path / "ttyUSB1.log"
+    log.write_text(
+        "I (3000) AMMETER_INA219: I=8.0mA V=3.7V P=29mW Rem=100.0%\n"
+        "I (5000) ROLE_SERVICE: Role: LEADER (aa)\n"
+        "I (6000) AMMETER_INA219: I=120.0mA V=3.7V P=444mW Rem=99.9%\n"
+        "I (7000) ROLE_SERVICE: Role: MEMBER (new leader: bb)\n"
+        "I (8000) AMMETER_INA219: I=24.0mA V=3.7V P=88mW Rem=99.8%\n"
+    )
+    stats = parse_logs([log])
+    assert stats["IDLE"].count == 1 and stats["IDLE"].mean_ma == 8.0
+    assert stats["LEADER"].mean_ma == 120.0
+    assert stats["MEMBER"].mean_ma == 24.0
+
+
+def test_parse_logs_prefere_calib_sem_duplicar(tmp_path):
+    log = tmp_path / "ttyUSB2.log"
+    log.write_text(
+        "I (6000) AMMETER_INA219: I=120.0mA V=3.7V P=444mW Rem=99.9%\n"
+        "I (6005) CALIB: role=LEADER I=120.0mA bat=99.9%\n"
+    )
+    stats = parse_logs([log])
+    assert stats["LEADER"].count == 1
+    assert "IDLE" not in stats

--- a/analysis/tests/test_calibration.py
+++ b/analysis/tests/test_calibration.py
@@ -57,3 +57,24 @@ def test_parse_logs_prefere_calib_sem_duplicar(tmp_path):
     stats = parse_logs([log])
     assert stats["LEADER"].count == 1
     assert "IDLE" not in stats
+
+
+def test_settle_descarta_transiente_pos_troca(tmp_path):
+    log = tmp_path / "ttyUSB0.log"
+    log.write_text(
+        "I (5000) CALIB: role=LEADER I=200.0mA bat=99.9%\n"  # pico no instante da troca
+        "I (9000) CALIB: role=LEADER I=120.0mA bat=99.8%\n"  # já acomodado (>=4000ms)
+    )
+    stats = parse_logs([log], settle_ms=4000)
+    assert stats["LEADER"].count == 1
+    assert stats["LEADER"].mean_ma == 120.0
+
+
+def test_settle_zero_mantem_tudo(tmp_path):
+    log = tmp_path / "ttyUSB0.log"
+    log.write_text(
+        "I (5000) CALIB: role=LEADER I=200.0mA bat=99.9%\n"
+        "I (9000) CALIB: role=LEADER I=120.0mA bat=99.8%\n"
+    )
+    stats = parse_logs([log], settle_ms=0)
+    assert stats["LEADER"].count == 2

--- a/analysis/tests/test_calibration.py
+++ b/analysis/tests/test_calibration.py
@@ -78,3 +78,26 @@ def test_settle_zero_mantem_tudo(tmp_path):
     )
     stats = parse_logs([log], settle_ms=0)
     assert stats["LEADER"].count == 2
+
+
+def test_cli_imprime_pronto_para_colar(tmp_path, capsys):
+    (tmp_path / "ttyUSB0.log").write_text(
+        "I (4050) CALIB: role=LEADER I=120.0mA bat=99.9%\n"
+        "I (5050) CALIB: role=LEADER I=120.0mA bat=99.9%\n"
+        "I (6050) CALIB: role=MEMBER I=24.0mA bat=99.7%\n"
+        "I (7050) CALIB: role=IDLE I=8.0mA bat=100.0%\n"
+    )
+    from analysis.calibration import main
+    rc = main([str(tmp_path), "--settle-ms", "0"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "LEADER_MA = 120.0" in out
+    assert "MEMBER_MA = 24.0" in out
+    assert "IDLE_MA = 8.0" in out
+
+
+def test_cli_sem_logs_retorna_erro(tmp_path, capsys):
+    from analysis.calibration import main
+    rc = main([str(tmp_path)])
+    assert rc == 1
+    assert "Nenhum log" in capsys.readouterr().out

--- a/analysis/tests/test_calibration.py
+++ b/analysis/tests/test_calibration.py
@@ -1,0 +1,16 @@
+import inspect
+from analysis import calibration, run
+
+
+def test_constantes_sao_floats():
+    assert isinstance(calibration.LEADER_MA, float)
+    assert isinstance(calibration.MEMBER_MA, float)
+    assert isinstance(calibration.IDLE_MA, float)
+
+
+def test_run_usa_as_constantes_centrais():
+    for fn in (run.generate, run.hetero_frames):
+        sig = inspect.signature(fn)
+        assert sig.parameters["leader_ma"].default == calibration.LEADER_MA
+        assert sig.parameters["member_ma"].default == calibration.MEMBER_MA
+        assert sig.parameters["idle_ma"].default == calibration.IDLE_MA

--- a/analysis/tests/test_figures.py
+++ b/analysis/tests/test_figures.py
@@ -46,3 +46,15 @@ def test_fig_f_tradeoff_writes_file(tmp_path):
     df = run.hetero_frames(seeds=(1,))
     path = figures.fig_cooldown_tradeoff(df, str(tmp_path))
     assert path is not None and os.path.exists(path) and os.path.getsize(path) > 0
+
+def test_generate_all_pula_b_e_d_sem_mortes(tmp_path):
+    # Calibrado com capacidade real (1000 mAh) nao alcanca o FND no horizonte
+    # curto -> B (FND) e D (residual no FND) devem PULAR, nao quebrar. A/C/E saem.
+    cal = calibrated(leader_ma=120, member_ma=25, idle_ma=8, capacity_mah=1000)
+    df = sim.run_frame(3, "round_robin", cal, seed=1, max_ms=20_000)
+    assert df[df["event"] == "node_death"].empty  # garante o cenario sem mortes
+    paths = figures.generate_all(df, str(tmp_path), idle_ma=8.0)
+    names = [os.path.basename(p) for p in paths]
+    assert not any(("fnd" in n) or ("residual" in n) for n in names)  # B e D ausentes
+    assert any("energia_por_papel" in n for n in names)  # A presente
+    assert len(paths) == 3  # A, C, E

--- a/analysis/tests/test_metrics.py
+++ b/analysis/tests/test_metrics.py
@@ -71,3 +71,28 @@ def test_energy_by_role_excludes_undecided():
     assert out["leader"] > out["member"]
     assert abs(out["leader"] - 120.0) < 1e-9
     assert abs(out["member"] - 25.0) < 1e-9
+
+def _df_sem_mortes():
+    """Calibrado: ha samples e lideranca, mas NENHUM node_death (capacidade nao
+    esgota no horizonte). Reproduz o cenario do --profile calibrated real."""
+    rows = [
+        dict(run_id="r", source="sim", policy="energy", cluster_size=3,
+             node_id="n0", t_ms=0, event="became_leader", role="leader",
+             current_ma=120.0, power_mw=float("nan"), residual=900.0, residual_pct=90.0),
+        dict(run_id="r", source="sim", policy="energy", cluster_size=3,
+             node_id="n0", t_ms=1000, event="sample", role="leader",
+             current_ma=120.0, power_mw=float("nan"), residual=899.0, residual_pct=89.9),
+        dict(run_id="r", source="sim", policy="energy", cluster_size=3,
+             node_id="n1", t_ms=1000, event="sample", role="member",
+             current_ma=25.0, power_mw=float("nan"), residual=950.0, residual_pct=95.0),
+    ]
+    return pd.DataFrame(rows)
+
+def test_residual_metrics_sem_mortes_nao_quebram():
+    # Sem node_death (FND inalcancado), as metricas de residual no FND devem
+    # retornar vazio-valido em vez de quebrar (KeyError: 'policy').
+    df = _df_sem_mortes()
+    rf = metrics.residual_at_fnd(df)
+    assert rf.empty and {"policy", "node_id", "residual"} <= set(rf.columns)
+    rs = metrics.residual_spread(df)
+    assert rs.empty and {"policy", "spread"} <= set(rs.columns)

--- a/docs/medicao-correntes.md
+++ b/docs/medicao-correntes.md
@@ -1,0 +1,51 @@
+# Roteiro — medição das correntes por papel (laboratório)
+
+Objetivo: capturar a corrente real de cada nó em cada papel (líder / membro /
+ocioso) para calibrar o perfil de energia da simulação (`analysis/`). A captura
+é automática: o firmware imprime uma linha `CALIB` por segundo e o `flash_all.sh`
+salva o log limpo de cada nó em `logs/`.
+
+## Pré-requisitos
+- Linux com ESP-IDF instalado (o `flash_all.sh` usa `/dev/ttyUSB*` e bash).
+- Firmware com a linha `CALIB` (Task 1 deste plano) já no código.
+- 3 ou mais ESPs com o INA219 ligado, alimentados pela bateria/fonte de medição.
+
+## Passo 1 — Flashar todos os nós
+```
+./flash_all.sh --backend ina219 --policy round_robin
+```
+- `--backend ina219`: usa o sensor INA219 (medição por I2C).
+- `--policy round_robin`: rotação previsível — todo nó vira líder na vez dele.
+- O script abre um monitor por nó e salva `logs/ttyUSB0.log`, `logs/ttyUSB1.log`, …
+
+## Passo 2 — Conferir o boot
+Em cada monitor, confirmar:
+- `AMMETER_INA219: INA219 OK (...)` — sensor inicializado.
+- Linhas `CALIB: role=... I=...mA bat=...%` aparecendo ~1×/s.
+
+## Passo 3 — Capturar o cluster (líder + membro)
+Deixar os 3+ nós rodando juntos por **≥ 2 mandatos completos** (~3 minutos; cada
+mandato de liderança dura 60 s). Isso garante que cada nó passe por **líder** e
+por **membro** com a rotação. Não precisa anotar nada à mão — os logs guardam tudo.
+
+## Passo 4 — Capturar o ocioso
+Desligar todos menos **um** nó (ou ligar só um). Sozinho, ele fica ~60 s em
+`role=IDLE` (sem líder, Wi-Fi STA desligado) antes de reiniciar. Deixar rodar
+~60 s. Pode repetir em 1–2 nós diferentes.
+
+## Passo 5 — Trazer os logs
+Copiar a pasta **`logs/`** inteira. É só disso que precisamos.
+
+## Depois (feito por nós, fora do laboratório)
+```
+python -m analysis.calibration logs/
+```
+Isso imprime média/desvio/contagem por papel e as 3 linhas prontas para colar em
+`analysis/calibration.py` (`LEADER_MA`, `MEMBER_MA`, `IDLE_MA`).
+
+## Cuidados
+- `[LEADER] Published:` é a corrente **do próprio líder**; `[LEADER] Member
+  reading:` é a corrente **de um membro** repassada pelo líder — não confundir.
+  A linha `CALIB` já resolve isso (cada amostra vem com o papel certo).
+- Deixar o filtro estabilizar: ignorar os primeiros segundos após cada troca de
+  papel (o parser já descarta esse transiente com `--settle-ms`).

--- a/main/src/Application/application_controller.cpp
+++ b/main/src/Application/application_controller.cpp
@@ -114,7 +114,8 @@ static void handle_leader() {
                  own_mac[5]);
         snprintf(payload, sizeof(payload),
                  "{\"temperature\": %.1f, \"current_ma\": %.1f, "
-                 "\"battery_pct\": %.1f, \"measured_time\": \"%s\"}",
+                 "\"battery_pct\": %.1f, \"role\": \"LEADER\", "
+                 "\"measured_time\": \"%s\"}",
                  temp, m.current_ma, m.battery_pct,
                  service::rtc::get_current_time().c_str());
 
@@ -134,7 +135,8 @@ static void handle_leader() {
                  sender[5]);
         snprintf(payload, sizeof(payload),
                  "{\"temperature\": %.1f, \"current_ma\": %.1f, "
-                 "\"battery_pct\": %.1f, \"measured_time\": \"%s\"}",
+                 "\"battery_pct\": %.1f, \"role\": \"MEMBER\", "
+                 "\"measured_time\": \"%s\"}",
                  temp, current_ma, battery_pct,
                  service::rtc::get_current_time().c_str());
 

--- a/main/src/Application/application_controller.cpp
+++ b/main/src/Application/application_controller.cpp
@@ -24,6 +24,18 @@ static const char *TAG = "APP_CONTROLLER";
 static void handle_leader();
 static void handle_member();
 
+static const char *role_label(service::application::role::Role r) {
+    using service::application::role::Role;
+    switch (r) {
+    case Role::LEADER:
+        return "LEADER";
+    case Role::MEMBER:
+        return "MEMBER";
+    default:
+        return "IDLE";
+    }
+}
+
 void controller::application::init() {
     service::ammeter::init();
     service::rtc::init();
@@ -45,6 +57,7 @@ void controller::application::init() {
 }
 
 void controller::application::handler(void *arg) {
+    uint32_t calib_ticks = 0;
     for (;;) {
         service::application::button::handler();
         service::application::discover::handler();
@@ -65,6 +78,18 @@ void controller::application::handler(void *arg) {
             break;
         default:
             break;
+        }
+
+        // Linha unica de calibracao (~1s): casa a corrente do INA219 com o papel
+        // atual, inclusive no ocioso (UNDECIDED->IDLE), que as linhas
+        // [LEADER]/[MEMBER] nao cobrem. Fonte preferida do parser
+        // analysis/calibration.py.
+        if (++calib_ticks >= 10) {
+            calib_ticks = 0;
+            auto m = service::ammeter::get_last_measurement();
+            ESP_LOGI("CALIB", "role=%s I=%.2fmA bat=%.1f%%",
+                     role_label(service::application::role::get_role()),
+                     m.current_ma, m.battery_pct);
         }
 
         vTaskDelay(100 / portTICK_PERIOD_MS);

--- a/server/server_mqtt.py
+++ b/server/server_mqtt.py
@@ -15,21 +15,23 @@ def init_db():
             temperatura REAL,
             corrente_ma REAL,
             bateria_pct REAL,
+            papel TEXT,
             measured_time TEXT,
             timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
         )
     ''')
-    # Migracao: adiciona measured_time em bancos ja existentes (CREATE TABLE
+    # Migracao: adiciona colunas em bancos ja existentes (CREATE TABLE
     # IF NOT EXISTS nao altera tabela ja criada).
-    try:
-        cursor.execute("ALTER TABLE leituras ADD COLUMN measured_time TEXT")
-    except sqlite3.OperationalError:
-        pass  # coluna ja existe
+    for col in ("measured_time TEXT", "papel TEXT"):
+        try:
+            cursor.execute(f"ALTER TABLE leituras ADD COLUMN {col}")
+        except sqlite3.OperationalError:
+            pass  # coluna ja existe
     conn.commit()
     conn.close()
 
 def on_connect(client, userdata, flags, rc, properties=None):
-    print(f"Conectado ao Broker (192.168.18.150). Codigo: {rc}")
+    print(f"Conectado ao Broker (127.0.0.1). Codigo: {rc}")
     client.subscribe("tcc/#")
     client.subscribe("/tcc/#")
 
@@ -42,18 +44,19 @@ def on_message(client, userdata, msg):
         temp = dados.get("temperature")
         corrente = dados.get("current_ma")
         bateria = dados.get("battery_pct")
+        papel = dados.get("role")
         measured_time = dados.get("measured_time")
 
         if temp is not None or corrente is not None:
             conn = sqlite3.connect(DB_NAME)
             cursor = conn.cursor()
             cursor.execute('''
-                INSERT INTO leituras (topico, temperatura, corrente_ma, bateria_pct, measured_time)
-                VALUES (?, ?, ?, ?, ?)
-            ''', (msg.topic, temp, corrente, bateria, measured_time))
+                INSERT INTO leituras (topico, temperatura, corrente_ma, bateria_pct, papel, measured_time)
+                VALUES (?, ?, ?, ?, ?, ?)
+            ''', (msg.topic, temp, corrente, bateria, papel, measured_time))
             conn.commit()
             conn.close()
-            print(f"[{msg.topic}] Salvo: Temp={temp}C | I={corrente}mA | Bat={bateria}% | t={measured_time}")
+            print(f"[{msg.topic}] Salvo: {papel} | Temp={temp}C | I={corrente}mA | Bat={bateria}% | t={measured_time}")
             
     except Exception as e:
         print(f"Erro no processamento: {e}")
@@ -63,9 +66,8 @@ client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
 client.on_connect = on_connect
 client.on_message = on_message
 
-# Use o IP que encontramos no seu ip addr
-#client.connect("192.168.18.150", 1883, 60)
-#client.loop_forever()
-
-client.connect("10.245.197.185", 1883, 60)
+# Broker mosquitto roda localmente neste notebook (mesma rede "samu" dos ESPs).
+# 127.0.0.1 e robusto a troca de IP por DHCP. Os ESPs publicam via MQTT_BROKER_URI
+# (sdkconfig) apontando para o IP deste host na rede "samu".
+client.connect("127.0.0.1", 1883, 60)
 client.loop_forever()


### PR DESCRIPTION
## Objetivo

Deixar pronta a calibração das correntes por papel (líder/membro/ocioso) para a
medição no laboratório da PUC — converter os logs seriais em 3 correntes que
alimentam o perfil calibrado da simulação, de forma objetiva e de uma única edição.

## O que entra

- **Firmware — linha `CALIB`** (`application_controller.cpp`): a cada ~1 s, casa a
  corrente do INA219 com o papel atual (`role=LEADER|MEMBER|IDLE`), inclusive no
  ocioso. Aditivo; não acopla o `AmmeterService` ao `role_service`.
- **Roteiro** (`docs/medicao-correntes.md`): passo a passo pro Samuel —
  `./flash_all.sh --backend ina219`, estabilizar ≥2 mandatos, capturar o ocioso
  (nó sozinho) e trazer a pasta `logs/`.
- **Parser + CLI** (`analysis/calibration.py`): `python -m analysis.calibration logs/`
  lê os logs (prefere `CALIB`, com fallback `ROLE_SERVICE`+`AMMETER`), descarta o
  transiente pós-troca (`--settle-ms`, default 5000) e imprime média/desvio/contagem
  por papel + as 3 linhas prontas pra colar.
- **Centralização**: as correntes viram `LEADER_MA/MEMBER_MA/IDLE_MA` em
  `analysis/calibration.py` (fonte única); `run.py` (defaults, `generate`,
  `hetero_frames`) consome de lá no lugar dos placeholders `120/25/8` repetidos.

## Como plugar a medição

Quando o Samuel trouxer os `logs/`: rodar `python -m analysis.calibration logs/` e
colar os 3 valores em `analysis/calibration.py`. As figuras calibradas saem com
`python -m analysis.run --profile calibrated`.

## Testes

`pytest analysis -q` → **68 passed, 1 xfailed** (o xfailed é o teste pré-existente
do cooldown homogêneo, alheio a este branch). CLI verificada ponta-a-ponta. O
firmware não foi compilado aqui (Windows sem ESP-IDF) — build/flash ocorrem no
laboratório; verificado por inspeção.

## Follow-ups (não-bloqueantes)

- M0: no boot, ~1–2 amostras IDLE de `0.0 mA` até a 1ª leitura do ammeter;
  mitigado pelo `--settle-ms` default (descarta os primeiros 5 s). Só afeta `--settle-ms 0`.
- Lacunas de teste menores (defaults do argparse; fallback com `settle_ms>0`).
