### PR TITLE
feat: persiste a energia dos ESPs no NVS entre reinícios

### DIFF
--- a/main/include/AmmeterService/ammeter_persistence.hpp
+++ b/main/include/AmmeterService/ammeter_persistence.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "AmmeterService/ammeter_service.hpp"
+
+// Persistência do consumo de bateria do ammeter no NVS, compartilhada pelos
+// dois backends (ADC e INA219), que duplicam o mesmo modelo de coulomb
+// counting. consumed_mah é a fonte da verdade; remaining_mah/battery_pct são
+// derivados dele.
+namespace service::ammeter::persistence {
+
+// Carrega consumed_mah/consumed_mwh do NVS (se existirem) e deriva
+// remaining_mah/battery_pct. Sem dados persistidos, deixa a bateria como está
+// (tipicamente cheia, definida pelo init do backend).
+void load(Measurement &m, float capacity_mah);
+
+// Grava o consumo quando ele varia >= 1% da capacidade desde a última
+// gravação (limita o desgaste do flash). Chamar a cada nova medição.
+void maybe_persist(const Measurement &m, float capacity_mah);
+
+} // namespace service::ammeter::persistence

--- a/main/include/Application/nvs_service.hpp
+++ b/main/include/Application/nvs_service.hpp
@@ -1,7 +1,17 @@
 #pragma once
 
+#include <cstdint>
+
 namespace service::application::nvs {
 
 void init();
 
-}
+// Persistência no namespace "energy" (usado pela bateria do ammeter e pelo
+// orçamento do energy_service). Escritas são raras (gravação por limiar).
+bool get_float(const char *key, float *out);
+void set_float(const char *key, float value);
+bool get_u32(const char *key, uint32_t *out);
+void set_u32(const char *key, uint32_t value);
+void erase_energy();
+
+} // namespace service::application::nvs

--- a/main/src/AmmeterService/ammeter_ina219_service.cpp
+++ b/main/src/AmmeterService/ammeter_ina219_service.cpp
@@ -6,6 +6,7 @@
 
 #ifdef CONFIG_AMMETER_BACKEND_INA219
 
+#include "AmmeterService/ammeter_persistence.hpp"
 #include "AmmeterService/ammeter_service.hpp"
 
 #include "driver/i2c_master.h"
@@ -139,6 +140,7 @@ void init() {
     last_measurement = {};
     last_measurement.remaining_mah = BATTERY_CAPACITY_MAH;
     last_measurement.battery_pct = 100.0f;
+    persistence::load(last_measurement, BATTERY_CAPACITY_MAH);
     last_sample_time_us = esp_timer_get_time();
     initialized = true;
 
@@ -238,6 +240,8 @@ void handler(void *arg) {
 
         last_sample_time_us = now;
         new_measurement_available = true;
+
+        persistence::maybe_persist(last_measurement, BATTERY_CAPACITY_MAH);
 
         ESP_LOGI(TAG, "I=%.2fmA V=%.3fV P=%.2fmW Rem=%.1f%%", filtered_ma,
                  vbus_v, power_mw, last_measurement.battery_pct);

--- a/main/src/AmmeterService/ammeter_persistence.cpp
+++ b/main/src/AmmeterService/ammeter_persistence.cpp
@@ -1,0 +1,63 @@
+#include "AmmeterService/ammeter_persistence.hpp"
+#include "Application/nvs_service.hpp"
+
+#include "esp_log.h"
+
+#include <algorithm>
+
+namespace service::ammeter::persistence {
+
+namespace nvs = service::application::nvs;
+
+static const char *TAG = "AMMETER_PERSIST";
+
+static constexpr char KEY_MAH[] = "consumed_mah";
+static constexpr char KEY_MWH[] = "consumed_mwh";
+
+// Fração da capacidade que dispara uma nova gravação (1%).
+static constexpr float PERSIST_FRACTION = 0.01f;
+
+// consumed_mah da última gravação; também atualizado no load.
+static float last_saved_mah = 0.0f;
+
+static void derive(Measurement &m, float capacity_mah) {
+    m.remaining_mah =
+        std::min(std::max(capacity_mah - m.consumed_mah, 0.0f), capacity_mah);
+    m.battery_pct = (m.remaining_mah / capacity_mah) * 100.0f;
+}
+
+void load(Measurement &m, float capacity_mah) {
+    float mah = 0.0f;
+    if (!nvs::get_float(KEY_MAH, &mah)) {
+        last_saved_mah = m.consumed_mah; // sem persistência: mantém o init (cheio)
+        ESP_LOGI(TAG, "Sem energia persistida — iniciando cheio");
+        return;
+    }
+
+    m.consumed_mah = mah;
+
+    float mwh = 0.0f;
+    if (nvs::get_float(KEY_MWH, &mwh)) {
+        m.consumed_mwh = mwh;
+    }
+
+    derive(m, capacity_mah);
+    last_saved_mah = m.consumed_mah;
+    ESP_LOGI(TAG, "Energia restaurada: consumed=%.1fmAh (%.1f%%)",
+             m.consumed_mah, m.battery_pct);
+}
+
+void maybe_persist(const Measurement &m, float capacity_mah) {
+    const float threshold = capacity_mah * PERSIST_FRACTION;
+    if (m.consumed_mah - last_saved_mah < threshold) {
+        return;
+    }
+
+    nvs::set_float(KEY_MAH, m.consumed_mah);
+    nvs::set_float(KEY_MWH, m.consumed_mwh);
+    last_saved_mah = m.consumed_mah;
+    ESP_LOGI(TAG, "Energia gravada: consumed=%.1fmAh (%.1f%%)", m.consumed_mah,
+             m.battery_pct);
+}
+
+} // namespace service::ammeter::persistence

--- a/main/src/AmmeterService/ammeter_service.cpp
+++ b/main/src/AmmeterService/ammeter_service.cpp
@@ -2,6 +2,7 @@
 
 #ifndef CONFIG_AMMETER_BACKEND_INA219
 
+#include "AmmeterService/ammeter_persistence.hpp"
 #include "AmmeterService/ammeter_service.hpp"
 
 #include "esp_adc/adc_cali.h"
@@ -135,6 +136,7 @@ void init() {
   last_measurement = {};
   last_measurement.remaining_mah = BATTERY_CAPACITY_MAH;
   last_measurement.battery_pct = 100.0f;
+  persistence::load(last_measurement, BATTERY_CAPACITY_MAH);
 
   last_sample_time_us = esp_timer_get_time();
   initialized = true;
@@ -226,6 +228,8 @@ void handler() {
 
   last_sample_time_us = now;
   new_measurement_available = true;
+
+  persistence::maybe_persist(last_measurement, BATTERY_CAPACITY_MAH);
 
   // adc_mv e offset incluidos no log para facilitar a calibracao:
   // rode o gear com I=0, leia adc_mv e ajuste CONFIG_AMMETER_OFFSET_MV.

--- a/main/src/Application/button_service.cpp
+++ b/main/src/Application/button_service.cpp
@@ -1,4 +1,5 @@
 #include "Application/button_service.hpp"
+#include "Application/nvs_service.hpp"
 
 #include "driver/gpio.h"
 #include "esp_log.h"
@@ -13,10 +14,13 @@ static const char *TAG = "BUTTON_SERVICE";
 
 constexpr gpio_num_t nBOOT_BUTTON = GPIO_NUM_9;
 
-// Hold BOOT this long to force a soft reset. Useful on the bench when a node
-// gets stuck in a Wi-Fi scan loop or stale role state and the EN button on
-// the C3 SuperMini clone is too small to reach reliably.
-constexpr uint32_t LONG_PRESS_MS = 2000;
+// Gestos no BOOT, decididos na SOLTURA (precisamos distinguir as durações).
+// Útil na bancada: a EN do clone C3 SuperMini é pequena demais p/ alcançar
+// com confiabilidade.
+//   2–5 s  -> soft reset (reinicia)
+//   > 5 s  -> zera a energia persistida (bateria + orçamento) e reinicia
+constexpr uint32_t RESTART_PRESS_MS = 2000;
+constexpr uint32_t RESET_PRESS_MS = 5000;
 
 void init() {
     gpio_config_t config = {.pin_bit_mask = (1ULL << nBOOT_BUTTON),
@@ -32,7 +36,6 @@ void handler() {
     static utils::Timer poll_timer;
     static utils::Timer press_timer;
     static bool was_pressed = false;
-    static bool restart_armed = false;
 
     if (!poll_timer.hasElapsed(50)) {
         return;
@@ -44,18 +47,22 @@ void handler() {
     bool pressed = (gpio_get_level(nBOOT_BUTTON) == 0);
 
     if (pressed && !was_pressed) {
-        press_timer.reset();
-        restart_armed = true;
+        press_timer.reset(); // começou a pressionar
     }
 
-    if (pressed && restart_armed && press_timer.hasElapsed(LONG_PRESS_MS)) {
-        ESP_LOGW(TAG, "BOOT held %u ms — restarting", LONG_PRESS_MS);
-        restart_armed = false;
-        esp_restart();
-    }
-
-    if (!pressed) {
-        restart_armed = false;
+    // Decide o gesto na soltura, pela duração do hold.
+    if (!pressed && was_pressed) {
+        if (press_timer.hasElapsed(RESET_PRESS_MS)) {
+            ESP_LOGW(TAG,
+                     "BOOT segurado >= %u ms — zerando energia e reiniciando",
+                     RESET_PRESS_MS);
+            service::application::nvs::erase_energy();
+            esp_restart();
+        } else if (press_timer.hasElapsed(RESTART_PRESS_MS)) {
+            ESP_LOGW(TAG, "BOOT segurado >= %u ms — reiniciando",
+                     RESTART_PRESS_MS);
+            esp_restart();
+        }
     }
 
     was_pressed = pressed;

--- a/main/src/Application/energy_service.cpp
+++ b/main/src/Application/energy_service.cpp
@@ -1,4 +1,5 @@
 #include "Application/energy_service.hpp"
+#include "Application/nvs_service.hpp"
 #include "esp_log.h"
 #include "utils.hpp"
 
@@ -10,6 +11,7 @@ static const char *TAG = "ENERGY_SERVICE";
 namespace service::application::energy {
 
 using controller::network::MacAddr;
+namespace nvs = service::application::nvs;
 
 // Initial budget in abstract units. Costs are calibrated relative to this.
 static constexpr uint32_t INITIAL_BUDGET   = 100'000;
@@ -27,7 +29,12 @@ static constexpr uint32_t TICK_PERIOD_MS   = 1000;
 // as invalid so the leader policy can fall back to round-robin.
 static constexpr uint32_t PEER_TTL_MS      = 10'000;
 
+// Persistência: grava no NVS quando o residual cai >= 1% do orçamento inicial.
+static constexpr uint32_t PERSIST_THRESHOLD = INITIAL_BUDGET / 100;
+static constexpr char     KEY_RESIDUAL[]    = "residual";
+
 static uint32_t      residual = INITIAL_BUDGET;
+static uint32_t      last_saved_residual = INITIAL_BUDGET;
 static utils::Timer  tick_timer;
 
 struct PeerSample {
@@ -51,10 +58,22 @@ static void decrement(uint32_t cost) {
     } else {
         residual -= cost;
     }
+
+    // residual só decresce e last_saved_residual >= residual, então a
+    // subtração é não-negativa.
+    if (last_saved_residual - residual >= PERSIST_THRESHOLD) {
+        nvs::set_u32(KEY_RESIDUAL, residual);
+        last_saved_residual = residual;
+    }
 }
 
 void init() {
     residual = INITIAL_BUDGET;
+    uint32_t saved = 0;
+    if (nvs::get_u32(KEY_RESIDUAL, &saved)) {
+        residual = saved;
+    }
+    last_saved_residual = residual;
     peers.clear();
     tick_timer.reset();
     ESP_LOGI(TAG, "Energy budget initialized: %u units", (unsigned)residual);

--- a/main/src/Application/nvs_service.cpp
+++ b/main/src/Application/nvs_service.cpp
@@ -1,14 +1,82 @@
 #include "Application/nvs_service.hpp"
 
 #include "esp_err.h"
+#include "esp_log.h"
+#include "nvs.h"
 #include "nvs_flash.h"
 
 namespace service::application::nvs {
+
+static const char *TAG = "NVS_SERVICE";
+
+// Namespace único para os dados de energia persistidos (bateria + orçamento).
+static constexpr char NAMESPACE[] = "energy";
 
 void init() {
     esp_err_t err = nvs_flash_init();
 
     ESP_ERROR_CHECK(err);
+}
+
+bool get_float(const char *key, float *out) {
+    nvs_handle_t handle;
+    if (nvs_open(NAMESPACE, NVS_READONLY, &handle) != ESP_OK) {
+        return false;
+    }
+    // NVS não tem tipo float: gravado/lido como blob de 4 bytes.
+    size_t size = sizeof(float);
+    esp_err_t err = nvs_get_blob(handle, key, out, &size);
+    nvs_close(handle);
+    return err == ESP_OK && size == sizeof(float);
+}
+
+void set_float(const char *key, float value) {
+    nvs_handle_t handle;
+    if (nvs_open(NAMESPACE, NVS_READWRITE, &handle) != ESP_OK) {
+        return;
+    }
+    esp_err_t err = nvs_set_blob(handle, key, &value, sizeof(value));
+    if (err == ESP_OK) {
+        nvs_commit(handle);
+    } else {
+        ESP_LOGW(TAG, "set_float(%s) falhou: %s", key, esp_err_to_name(err));
+    }
+    nvs_close(handle);
+}
+
+bool get_u32(const char *key, uint32_t *out) {
+    nvs_handle_t handle;
+    if (nvs_open(NAMESPACE, NVS_READONLY, &handle) != ESP_OK) {
+        return false;
+    }
+    esp_err_t err = nvs_get_u32(handle, key, out);
+    nvs_close(handle);
+    return err == ESP_OK;
+}
+
+void set_u32(const char *key, uint32_t value) {
+    nvs_handle_t handle;
+    if (nvs_open(NAMESPACE, NVS_READWRITE, &handle) != ESP_OK) {
+        return;
+    }
+    esp_err_t err = nvs_set_u32(handle, key, value);
+    if (err == ESP_OK) {
+        nvs_commit(handle);
+    } else {
+        ESP_LOGW(TAG, "set_u32(%s) falhou: %s", key, esp_err_to_name(err));
+    }
+    nvs_close(handle);
+}
+
+void erase_energy() {
+    nvs_handle_t handle;
+    if (nvs_open(NAMESPACE, NVS_READWRITE, &handle) != ESP_OK) {
+        return;
+    }
+    nvs_erase_all(handle);
+    nvs_commit(handle);
+    nvs_close(handle);
+    ESP_LOGW(TAG, "Energia persistida apagada (namespace '%s')", NAMESPACE);
 }
 
 } // namespace service::application::nvs


### PR DESCRIPTION
## O quê
Antes, religar o ESP (cortar a fonte) zerava a **bateria medida** e o **orçamento de energia da eleição** — tudo voltava a 100%. Agora ambos persistem no **NVS** (namespace `"energy"`) e são restaurados no boot.

## Como
- **`nvs_service`** — camada de acesso ao NVS no namespace `"energy"`: `get/set_float` (float gravado como blob de 4 bytes), `get/set_u32`, `erase_energy()`.
- **Bateria (ammeter)** — novo helper `ammeter_persistence` compartilhado pelos dois backends (ADC e INA219): `load()` no `init` (carrega `consumed_mah`/`consumed_mwh`, deriva `remaining_mah`/`battery_pct`) e `maybe_persist()` após cada medição.
- **`energy_service`** — carrega o `residual` no `init` e grava no `decrement`.
- **`button_service`** — gesto agora decidido na **soltura** do BOOT: 2–5 s reinicia (como antes); **> 5 s zera a energia persistida e reinicia** (começar um experimento novo em 100%).

## Decisões de design
- **Gravação por limiar** (≥ 1% desde a última gravação): ~100 escritas por descarga total → desgaste ínfimo do flash. O corte de energia é abrupto, então não há save-on-shutdown — daí gravar durante a operação.
- Sem dados no NVS = comportamento atual (bateria/orçamento cheios).
- Limiares por `constexpr` (não são relevantes p/ a simulação → fora de `params.py`/fidelidade).

## ⚠️ Atenção — validar no lab
Este código **não foi compilado** (sem ESP-IDF no ambiente) — é o **primeiro build real** desta versão. Antes de mergear, buildar/flashar (INA219) e validar:
1. Deixar a bateria cair alguns %, **cortar a fonte**, religar → `battery_pct` retoma de onde parou (não 100%).
2. Segurar BOOT **> 5 s** → volta a 100%.
3. Conferir os logs `AMMETER_PERSIST: Energia restaurada/gravada`.

Nota: o `handler()` do backend **ADC** é não-conectado (pré-existente — nunca chamado), então a persistência efetiva roda no **INA219** (o do lab). Fora do escopo corrigir essa fiação.

## Verificação automatizada
`python -m pytest analysis -q` → **70 passed, 1 xfailed** (a fidelidade lê o `energy_service.cpp` editado e segue extraindo as constantes corretamente).
